### PR TITLE
Fix prerequisites typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 * Scrollen nicht vergessen: Scrolle immer ganz nach unten, um wirklich alle Schritte zu sehen. Sonst verpasst du Teile des Tutorials!
 * Auf Links klicken: Wenn du eine blau unterstrichene Stelle (Link) siehst, musst du darauf klicken. Dort geht das Tutorial weiter oder es öffnet sich ein zusätzlicher Inhalt.
 
-## Einführung 
-Vorraussetzungen: 🌱 IoT Basics abgeschlossen  
+## Einführung
+Voraussetzungen: 🌱 IoT Basics abgeschlossen
 Schwierigkeitsgrad: 🔥🔥⚪⚪
 
 In diesem Tutorial baust du Schritt für Schritt ein Programm auf, das den Seifenstand simuliert und die Daten über 🛜 LoRa ins Internet sendet.

--- a/docs/tutorials/toilette-part-1.md
+++ b/docs/tutorials/toilette-part-1.md
@@ -9,13 +9,13 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 
 ## 📗 Einführung,  Teil 1
 
-**Vorraussetzungen**
+**Voraussetzungen**
 * Micro:Bit Basics: 
     * Du kannst Programme erstellen und herunterladen.
     * Du kennst die Einstiegspunkte "Beim Start" und "Dauerhaft".
     * Dir ist klar, dass Programme in der Regel schrittweise (von oben nach unten) abgearbeitet werden.
     Zudem kannst Du Schleifen und Verzweigungen einsetzen.
-    * es ist bekannnt, dass Kategorien Blöcke (z.B. ``||basic:Grundlagen||``) beinhalten, welche in Programmen genutzt werden können
+    * es ist bekannt, dass Kategorien Blöcke (z.B. ``||basic:Grundlagen||``) beinhalten, welche in Programmen genutzt werden können
     * Variablen können erstellt, verwendet und verändert werden
 
 **Lernergebnis**
@@ -33,7 +33,7 @@ du ein funktionsfähiges Programm, das...
 
 Klicke auf das 💡- Symbol, falls Du zusätzliche Hilfe brauchst und um deinen Code zu überprüfen.
 
-## 👁️ Vorraussetzungen @showdialog
+## 👁️ Voraussetzungen @showdialog
 * Für Teil 1 brauchst Du grundsätzlich nur einen Micro:Bit. 
 * Falls du lieber gleich den IoT- Cube nehmen möchtest, kannst du ihn so anschliessen:
 ![Bild](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/iot-cube-anschliessen-klein.png)


### PR DESCRIPTION
## Summary
- correct typo in README
- fix spelling in toilette tutorial

## Testing
- `make test` *(fails: pxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499834f9fc832788abb9114eb922cb