### PR TITLE
Add queue sensor tutorial

### DIFF
--- a/docs/static/tutorials/3dModel/warteschlange3dViewer.html
+++ b/docs/static/tutorials/3dModel/warteschlange3dViewer.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>3D STL Viewer</title>
+  <style>
+    body { margin: 0; }
+    canvas { display: block; }
+  </style>
+
+  <!-- Import-Map, löst "three" auf -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.156.1/build/three.module.js"
+    }
+  }
+  </script>
+</head>
+<body>
+  <script type="module">
+    import * as THREE from 'three';
+    import { STLLoader }   from 'https://cdn.jsdelivr.net/npm/three@0.156.1/examples/jsm/loaders/STLLoader.js';
+    import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.156.1/examples/jsm/controls/OrbitControls.js';
+
+    // Rest Deines Codes (unverändert) …
+    const scene    = new THREE.Scene();
+    const camera   = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setClearColor(0xf0f0f0);
+    document.body.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(0, 1, 1).normalize();
+    scene.add(light);
+
+    let mesh;
+
+    const loader = new STLLoader();
+    loader.load('warteschlangeSensor.stl', geometry => {
+      const material = new THREE.MeshPhongMaterial({ color: 0xD2B48C });
+      mesh     = new THREE.Mesh(geometry, material);
+      mesh.rotation.x = -Math.PI/8;
+      mesh.rotation.y = Math.PI;
+      mesh.rotation.z = 0;
+      scene.add(mesh);
+    });
+
+    camera.position.z = 300;
+
+    function animate() {
+      requestAnimationFrame(animate);
+      controls.update();
+
+      // Optional: Rotation für Animation
+      if(mesh){
+        mesh.rotation.z += 0.01;
+        mesh.rotation.y += 0.001;
+    }
+
+      renderer.render(scene, camera);
+    }
+    animate();
+  </script>
+</body>
+</html>

--- a/docs/tutorials/warteschlange-sensorik-teil1-solution.md
+++ b/docs/tutorials/warteschlange-sensorik-teil1-solution.md
@@ -1,0 +1,100 @@
+```package
+iot-cube=github:Smartfeld/pxt-iot-cube#v1.1.2
+sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
+```
+### @explicitHints false
+
+# Warteschlange Sensorik Teil 1
+## Lösung
+
+* Unten findest du die komplette Lösung.
+* Drücke 📥`|Download|` und teste das Programm.
+
+```template
+function schreibeMesswertAufDisplay (wert: number, position: number) {
+    smartfeldAktoren.oledWriteNum(position)
+    smartfeldAktoren.oledWriteStr(": ")
+    stringMessung = convertToText(wert)
+    smartfeldAktoren.oledWriteStr(stringMessung)
+    for (let index = 0; index < 6 - stringMessung.length; index++) {
+        smartfeldAktoren.oledWriteStr(" ")
+    }
+    listPos += 1
+    if (position % 2 == 0) {
+        smartfeldAktoren.oledNewLine()
+    }
+}
+function messeMax () {
+    ANZAHL_MESSUNGEN = 10
+    maximum = 0
+    for (let index = 0; index < ANZAHL_MESSUNGEN; index++) {
+        maximum = Math.max(maximum, smartfeldSensoren.getHalfWord_Visible())
+    }
+    return Math.round(maximum)
+}
+function messeHelligkeitsUnterschied (ledNr: number) {
+    led_strip.setPixelColor(ledNr, neopixel.colors(NeoPixelColors.Black))
+    led_strip.show()
+    h_umgebung = messeMax()
+    led_strip.setPixelColor(ledNr, neopixel.colors(NeoPixelColors.White))
+    led_strip.show()
+    h_mitLED = messeMax()
+    h_unterschied = h_mitLED - h_umgebung
+    led_strip.setPixelColor(ledNr, neopixel.colors(NeoPixelColors.Black))
+    led_strip.show()
+    return h_unterschied
+}
+function messen () {
+    m_list = []
+    LedPos = ERSTE_LED_POS
+    for (let index = 0; index < ANZAHL_LEDS; index++) {
+        m_list.push(messeHelligkeitsUnterschied(LedPos))
+        LedPos += 1
+    }
+    return m_list
+}
+let wertLeerMinusMessung = 0
+let personen = 0
+let LedPos = 0
+let m_list: number[] = []
+let h_unterschied = 0
+let h_mitLED = 0
+let h_umgebung = 0
+let maximum = 0
+let ANZAHL_MESSUNGEN = 0
+let listPos = 0
+let stringMessung = ""
+let list_messungen: number[] = []
+let led_strip: neopixel.Strip = null
+let ERSTE_LED_POS = 0
+let ANZAHL_LEDS = 0
+smartfeldSensoren.initSunlight()
+ANZAHL_LEDS = 9
+ERSTE_LED_POS = 2
+smartfeldAktoren.oledInit(128, 64)
+led_strip = neopixel.create(DigitalPin.P1, 16, NeoPixelMode.RGB_RGB)
+led_strip.setBrightness(255)
+let list_leermessungen = messen()
+for (let index = 0; index < ANZAHL_LEDS; index++) {
+    list_leermessungen.push(0)
+    list_messungen.push(0)
+}
+basic.forever(function () {
+    personen = 0
+    if (input.buttonIsPressed(Button.A)) {
+        list_leermessungen = messen()
+    } else {
+        list_messungen = messen()
+        smartfeldAktoren.oledClear()
+        listPos = 0
+        for (let index = 0; index < ANZAHL_LEDS; index++) {
+            wertLeerMinusMessung = list_leermessungen[listPos] - list_messungen[listPos]
+            if (wertLeerMinusMessung > 70) {
+                personen += 1
+            }
+            schreibeMesswertAufDisplay(wertLeerMinusMessung, listPos)
+        }
+        basic.showNumber(personen)
+    }
+})
+```

--- a/docs/tutorials/warteschlange-sensorik-teil1.md
+++ b/docs/tutorials/warteschlange-sensorik-teil1.md
@@ -1,0 +1,57 @@
+```package
+iot-cube=github:Smartfeld/pxt-iot-cube#v1.1.2
+sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
+```
+### @explicitHints false
+
+# Warteschlange Sensorik Teil 1
+
+## 📗 Einführung
+
+In diesem Tutorial baust du eine Lichtschranke mit einem RGB-LED-Streifen und einem Lichtsensor auf. Mit dem 3D-gedruckten Modell kannst du Lego-Figuren zählen, die durch die Lichtschranke fahren.
+
+Lade das STL-Modell hier herunter: [🌍3D-Modell](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/3dModel/warteschlange3dViewer.html)
+
+**Voraussetzungen**
+* Micro:Bit Basics
+* Einen 16er RGB-LED-Streifen (9 LEDs werden genutzt)
+* Einen Lichtsensor am IoT Cube
+
+**Lernergebnis**
+Am Ende dieses Tutorials besitzt du ein Programm, das die Anzahl der vorbeigeführten Figuren zählt und auf dem Display anzeigt.
+
+## 👁️ Voraussetzungen @showdialog
+* Schliesse den RGB-LED-Streifen an Pin P1 an.
+* Verbinde den Lichtsensor mit dem IoT Cube.
+
+## 🧱 LEDs initialisieren
+* Lege eine Variable **ANZAHL_LEDS** mit dem Wert 9 an.
+* Erstelle eine Variable **ERSTE_LED_POS** mit dem Wert 2. Damit beginnen wir bei LED 2 zu messen.
+* Initialisiere den LED-Streifen mit ``||neopixel:create||`` an Pin P1 und 16 LEDs.
+* Setze die Helligkeit mit ``||neopixel:set brightness||`` auf 255.
+
+## 🔍 Helligkeit messen
+* Schreibe eine Funktion **messeMax**, welche 10 Mal den Lichtsensor liest und den grössten Wert zurückgibt.
+* Baue eine Funktion **messeHelligkeitsUnterschied(ledNr)**, welche die Umgebung misst, danach die LED einschaltet, erneut misst und die Differenz zurückgibt.
+* In einer Funktion **messen** wird für jede verwendete LED der Unterschied gemessen und in eine Liste geschrieben.
+
+```blocks
+function messeMax () {
+    ANZAHL_MESSUNGEN = 10
+    maximum = 0
+    for (let index = 0; index < ANZAHL_MESSUNGEN; index++) {
+        maximum = Math.max(maximum, smartfeldSensoren.getHalfWord_Visible())
+    }
+    return Math.round(maximum)
+}
+```
+
+## 👥 Figuren zählen
+* Miss beim Start die Werte ohne Figuren und speichere sie in **list_leermessungen**.
+* In der ``||basic:forever||``-Schleife misst du erneut. Ziehe die aktuellen Werte von den Leerwerten ab.
+* Ist der Unterschied grösser als 70, wird eine Figur gezählt.
+* Gib die Werte auf dem OLED-Display aus und zeige die Anzahl Figuren an.
+
+## Gratuliere 🏆 – du hast Teil 1 abgeschlossen 🚀
+
+[Zur Lösung](https://makecode.microbit.org/#tutorial:github:reifab/pxt-iot-tutorial/docs/tutorials/warteschlange-sensorik-teil1-solution)

--- a/pxt.json
+++ b/pxt.json
@@ -17,6 +17,8 @@
         "docs/tutorials/seifenspender-part-1-solution.md",
         "docs/tutorials/seifenspender-part-2-solution.md",
         "docs/tutorials/seifenspender-part-3-solution.md"
+        ,"docs/tutorials/warteschlange-sensorik-teil1.md"
+        ,"docs/tutorials/warteschlange-sensorik-teil1-solution.md"
     ],
     "testFiles": [
         "test.ts"


### PR DESCRIPTION
## Summary
- add `warteschlange-sensorik-teil1` tutorial and solution
- ship 3D viewer HTML for queue sensor model
- include new docs in `pxt.json`
- remove placeholder STL model

## Testing
- `npx pxt test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849aabe4c58832786cd73c35506953c