### PR TITLE
Fix typos in German tutorials

### DIFF
--- a/docs/tutorials/seifenspender-part-1.md
+++ b/docs/tutorials/seifenspender-part-1.md
@@ -145,7 +145,7 @@ basic.forever(function () {
 Nun wollen wir den Seifenstand 🧼 wieder auffüllen, wenn Knopf B gedrückt wird.
 Dazu benötigen wir eine Bedingung, die prüft, ob Knopf B gedrückt wurde. Wenn dies der Fall ist, soll der Seifenstand 🧼 auf 100% gesetzt werden.
 * Hol dir den Block ``||Logic:wenn wahr dann||`` und ziehe ihn in
-die ``dauerhaft`` Schleife, überhalb von ``||basic:pausiere (ms)||``
+die ``dauerhaft`` Schleife, oberhalb von ``||basic:pausiere (ms)||``
 * Schiebe den Block ``||Input:Knopf A ist geklickt||`` auf das Feld ``wahr``
 und ändere Knopf A zu Knopf **B**
 * Setze den Seifenstand auf 100% indem du die Variable ``||variables:seifenstandInProzent||``🧼 auf 100 setzt.

--- a/docs/tutorials/seifenspender-part-3.md
+++ b/docs/tutorials/seifenspender-part-3.md
@@ -378,7 +378,7 @@ function initialisiereLoRaVerbindung () {
 * Drücke 📥`|Download|`
 * Prüfe, ob in der Cloud Änderungen des Seifenstands 🧼 angezeigt werden: [iot.claviscloud.ch](https://iot.claviscloud.ch/dashboards/)
 * Behebe gegebenenfalls aufgetretene Fehler. Klicke auf das 💡- Symbol, um den gesamten Code des "Seifenspenders" anzuzeigen.
-* Energie sparen: Displays (das LED- sowie das OLED- Display) brauchen relativ viel Storm. Kannst Du den Code optimieren, sodass die beiden Displays nur bei Seifenstand- Änderungen aktiv sind?
+* Energie sparen: Displays (das LED- sowie das OLED- Display) brauchen relativ viel Strom. Kannst Du den Code optimieren, sodass die beiden Displays nur bei Seifenstand- Änderungen aktiv sind?
 
 ```blocks
 function initialisiereLoRaVerbindung () {

--- a/docs/tutorials/toilette-part-1.md
+++ b/docs/tutorials/toilette-part-1.md
@@ -93,7 +93,7 @@ basic.forever(function () {
 }
 ```
 
-## 🧼 Flüllstand kleiner 0 verhindern
+## 🧼 Füllstand kleiner 0 verhindern
 * 🧼 Versuche mit dem Block ``||Logic:wenn wahr dann||`` Füllstände kleiner als 0 zu verhindern. 
 * 🧼 Setze den Füllstand auf 0 sollte der Füllstand die 0 unterschreiten.
 [Hier findest du weitere Informationen zu logischen Operatoren](https://makecode.microbit.org/blocks/logic/boolean)

--- a/docs/tutorials/warteschlange-sensorik-teil1.md
+++ b/docs/tutorials/warteschlange-sensorik-teil1.md
@@ -92,7 +92,7 @@ ein.
 * Wiederhole die Messung sowie die Anzeige unter Verwendung der Variable **h_mitLED**. Die Messung kannst Du nach dem zweiten **strip anzeigen** einfügen. 
 * 📥 Drücke `|Download|` und beobachte die Werte auf dem Display🖥️ . Beantworte
 für dich folgende Fragen:
-  * Wie gross ist der Unterschied der Messwerte (Umgebungungslicht - Licht mit LED)
+  * Wie gross ist der Unterschied der Messwerte (Umgebungslicht - Licht mit LED)
   * Wie stark lassen sich die Werte von Fremdlicht beeinflussen?
   * Wie stark streuen die Messwerte bei scheinbar konstantem Fremdlicht?
 
@@ -132,7 +132,7 @@ basic.forever(function () {
 Nach diesen Fragestellungen hast du wohlmöglich bemerkt, dass
   * die Einzelmessungen auch unter gleichen Bedingungen 
   relativ stark variieren, ca. +/- 40 Lumen
-  * Erhöht man das Fremdlich, erhöht sich der Hell- sowie der Dunkelwert inetwa gleich
+  * Erhöht man das Fremdlicht, erhöht sich der Hell- sowie der Dunkelwert in etwa gleich
 
 Gründe für die Unterschiede: Künstliches Licht (z. B. LEDs oder Neonröhren) 
 kann stark Flackern, auch wenn wir dies nicht wahrnehmen.
@@ -173,7 +173,7 @@ function messeMax () {
 ## 🔍 Mehrfachmessung (Funktion messeMax) einsetzen und testen
 
 * Ersetze in der ``dauerhaft`` - Schleife die zwei Blöcke ``||SmartfeldSensoren:gib sichtbares Licht [lm]||``
-  druch je einen Fuktionsaufruf ``||functions:Aufruf messeMax||``
+  durch je einen Funktionsaufruf ``||functions:Aufruf messeMax||``
 * 📥 Drücke `|Download|` und beobachte die Werte auf dem Display🖥️. Beantworte
 für dich folgende Fragen:
   * Sind die Messwerte gegenüber vorher konstanter?
@@ -233,7 +233,7 @@ Versuchen wir es!
 * ``||variables:Erstelle eine variable...||`` mit dem Namen h_unterschied
 * Nimm den Block ``||math:0 - 0||`` und ziehe das Umgebungslicht (h_umgebung) 
 vom zweiten Messwert (h_mitLED) ab.
-* Stelle auf dem Display🖥️ nur noch den Unterschied dar. Enferne die nicht 
+* Stelle auf dem Display🖥️ nur noch den Unterschied dar. Entferne die nicht 
 mehr benötigten Display- Ausgaben.
 * Die erste Pause kannst du ebenfalls entfernen, die zweite Pause ist immer noch sinnvoll, 
 damit du die Werte besser ablesen kannst.
@@ -411,14 +411,14 @@ basic.forever(function () {
 ## An mehreren Positionen Personen erkennen und zählen
 
 * Bewerkstellige mit dem Block ``||loops:für Index von 0 bis 4|`` eine neunfache
-Ausführung der vorhergehend erwähnten Blöcken. Du must dafür die Zahl von 4 auf 8
+Ausführung der vorhergehend erwähnten Blöcken. Du musst dafür die Zahl von 4 auf 8
 ändern.
 * Ersetze die LED- Nummer (im Moment = 2) durch ``||math:0+0||``, wobei du 0 + 0
 wiederum änderst zu der Addition ``||variables:Index||``+ 2. Dies ist nötig, 
 damit zuerst die LED mit Index 2 brennt.
 * Schalte nach jedem Durchlauf (zuunterst in der Schleife), alle LEDs aus mit dem
 Block  ``||neopixel:strip ausschalten||``.
-* Enferne alle Blöcke ``||basic:pausiere (ms)|| aus dem Code, diese sind nicht 
+* Entferne alle Blöcke ``||basic:pausiere (ms)|| aus dem Code, diese sind nicht 
 mehr nötig.
 * Bewerkstellige einen Zeilenumbruch mit dem Block
 ``||SmartfeldAktoren:Zeilenumbruch||`` direkt nach der Ausgabe 

--- a/overview.md
+++ b/overview.md
@@ -5,7 +5,7 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 
 # Dies ist ein Tutorial für den IoT Cube
 
-Vorraussetzungen: 🌱 IoT Basics abgeschlossen  
+Voraussetzungen: 🌱 IoT Basics abgeschlossen  
 Schwierigkeitsgrad: 🔥🔥⚪⚪
 
 In diesem Tutorial baust du Schritt für Schritt ein Programm auf, 


### PR DESCRIPTION
## Summary
- correct spelling mistakes across all tutorial docs

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: pxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655f04210c8327a661082c302fc80a