### PR TITLE
Fix minor spelling mistakes in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Übersicht
 
-In diesem Repository sind zwei Makecode- Tutorials mit mehreren Teilen enthalten:
+In diesem Repository sind zwei Makecode-Tutorials mit mehreren Teilen enthalten:
 
 ### Seifenspender
 
@@ -15,7 +15,7 @@ In diesem Tutorial wird Schritt für Schritt ein Programm aufgebaut, das den Sei
 
 ### Warteschlange
 
-In diesem Tutorial wird eine Warteschlange simuliert für eine Smarte Toilette, um die wartenden Personen automatisiert zu zählen.
+In diesem Tutorial wird eine Warteschlange simuliert für eine smarte Toilette, um die wartenden Personen automatisiert zu zählen.
 
 * [Einstiegspunkt Warteschlange](https://makecode.microbit.org/#tutorial:github:reifab/pxt-iot-tutorial/docs/tutorials/warteschlange-overview)
 * [Teil 1 - noch ohne Internetverbindung](https://makecode.microbit.org/#tutorial:github:reifab/pxt-iot-tutorial/docs/tutorials/warteschlange-sensorik-part-1)

--- a/docs/tutorials/seifenspender-part-1-solution.md
+++ b/docs/tutorials/seifenspender-part-1-solution.md
@@ -8,7 +8,7 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 ## Lösung
 
 * Unten die Lösung von Tutorial Teil 1 
-* Drücke 📥`|Download|`und teste das Programm.
+* Drücke 📥 `|Download|` und teste das Programm.
 
 ```template
 let seifenstandInProzent = 100

--- a/docs/tutorials/seifenspender-part-2-solution.md
+++ b/docs/tutorials/seifenspender-part-2-solution.md
@@ -8,7 +8,7 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 ## Lösung
 
 * Unten die Lösung von Tutorial Teil 2 
-* Drücke 📥`|Download|`und teste das Programm.
+* Drücke 📥 `|Download|` und teste das Programm.
 
 ```template
 

--- a/docs/tutorials/seifenspender-part-3-solution.md
+++ b/docs/tutorials/seifenspender-part-3-solution.md
@@ -8,7 +8,7 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 ## Lösung
 
 * Unten die Lösung von Tutorial Teil 3 
-* Drücke 📥`|Download|`und teste das Programm.
+* Drücke 📥 `|Download|` und teste das Programm.
 
 ```template
 

--- a/docs/tutorials/warteschlange-sensorik-part-1-solution.md
+++ b/docs/tutorials/warteschlange-sensorik-part-1-solution.md
@@ -9,7 +9,7 @@ neopixel=github:microsoft/pxt-neopixel#v0.7.6
 ## Lösung
 
 * Unten findest du die komplette Lösung.
-* Drücke 📥`|Download|` und teste das Programm.
+* Drücke 📥 `|Download|` und teste das Programm.
 
 ```template
 function schreibeInfosAufDisplay (position: number, wert: number, _symbol: string) {

--- a/docs/tutorials/warteschlange-sensorik-part-1.md
+++ b/docs/tutorials/warteschlange-sensorik-part-1.md
@@ -15,7 +15,7 @@ Steht etwas zwischen Sensor👁️ und LED💡, zum Beispiel eine Lego-Figur🦹
 verringert sich die Helligkeit.
 So erkennen wir, ob an einer bestimmten Position etwas im Lichtstrahl steht.
 Die Messungen werden an neun Positionen in der Warteschlange nacheinander 
-vorgenommen, sodass dieL ego-Figuren🦹‍♂️gezählt werden können.
+vorgenommen, sodass die Lego-Figuren🦹‍♂️gezählt werden können.
 
 Schau Dir dieses Video an, welches das Messprinzip illustriert:
 * [Video🎬 ansehen: Warteschlange Sensorik](https://wiki.smartfeld.ch/lib/exe/fetch.php?media=warteschlange_sensorik.mp4)

--- a/docs/tutorials/warteschlange-sensorik-part-2-solution.md
+++ b/docs/tutorials/warteschlange-sensorik-part-2-solution.md
@@ -9,7 +9,7 @@ neopixel=github:microsoft/pxt-neopixel#v0.7.6
 ## Lösung
 
 * Unten findest du die komplette Lösung.
-* Drücke 📥`|Download|` und teste das Programm.
+* Drücke 📥 `|Download|` und teste das Programm.
 
 ```template
 

--- a/docs/tutorials/warteschlange-sensorik-part-2.md
+++ b/docs/tutorials/warteschlange-sensorik-part-2.md
@@ -38,7 +38,7 @@ Falls dir bezüglich dieser Funktionen etwas unklar ist, überlege, vorgängig n
 
 ## 🛜 Verbindung mit Internet aufbauen
 
-Zu Beginn bauen wir eine Verbindung zum Internet auf. Dazu bennötigen wir einen Funktionsaufruf.
+Zu Beginn bauen wir eine Verbindung zum Internet auf. Dazu benötigen wir einen Funktionsaufruf.
 
 * Hol dir den Block ``||functions:Aufruf initialisiereLoRaVerbindung ||`` und ziehe diesen zuunterst in den Block **beim Start**.
 
@@ -140,7 +140,7 @@ basic.forever(function () {
 
 Bis jetzt wird die Personenanzahl in der 'Dauerhaft'- Schleife lediglich angezeigt, aber noch nicht gesendet. Dies wollen wir nun ändern:
 
-* Ersetzte den Block ``||basic:showNumber(anzahlPersonenInWarteschlange)||`` durch ``||functions:Aufruf sendeUndZeigePersonenanzahl||``.
+* Ersetze den Block ``||basic:showNumber(anzahlPersonenInWarteschlange)||`` durch ``||functions:Aufruf sendeUndZeigePersonenanzahl||``.
 * 📥 Drücke `|Download|` und kontrolliere das LED-Anzeige🟥 und das OLED-Display🖥️:  
 Teste, ob die Personen beim Platzieren von z.B.drei Duplo- Figuren🦹‍♂️ korrekt gezählt werden. Direkt nach der Anzeige der Zahl müsste auch der Ladebalken auf dem OLED-Display🖥️ für 5 Sekunden erscheinen<br />
 🟥🟥🟥🟥🟥  
@@ -244,7 +244,7 @@ Nun geht es an die Visualisierung der Daten auf der Clavis Cloud ☁️.
 * Rufe die Website [🌍iot.claviscloud.ch](https://iot.claviscloud.ch/home) auf.
 * Melde dich an (Login- Informationen kriegst Du von der Lehrperson/ Kursleitung).
 * Erweitere dein Dashboard mit einem Warteschlangen- Widget, falls noch nicht vorhanden.
-* Wähle im Widget als **Datenquelle** als **Gerät** deinen IoT- Cube (gemäss Aufschift) aus.
+* Wähle im Widget als **Datenquelle** als **Gerät** deinen IoT- Cube (gemäss Aufschrift) aus.
 * Wähle als **Data key** **Ganzzahl_ID_0** aus.
 * Klicke auf **Speichern** und teste, ob die Anzahl Personen gesendet und dargestellt wird.
 


### PR DESCRIPTION
## Summary
- fix Markdown typos across tutorials
- adjust README wording

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68792394e8388327ad9c17aefb4b201d