### PR TITLE
Improve clarity and spelling in smart toilet tutorial part 3

### DIFF
--- a/docs/tutorials/smart-toilet-part-3.md
+++ b/docs/tutorials/smart-toilet-part-3.md
@@ -10,26 +10,26 @@ sensors=github:Smartfeld/pxt-sensorikAktorikSmartfeld
 
 **Voraussetzungen**
 
-🌱 IoT Basics abgeschlossen und Smart Toilet Tutorial [Teil 2 - mit Internetverbindung](https://makecode.microbit.org/#tutorial:github:fave-smartfeld/pxt-smart-toilet-tutorial/docs/tutorials/smart-toilet-part2) abgeschlossen.
+🌱 IoT Basics abgeschlossen und das Smart-Toilet-Tutorial [Teil 2 – mit Internetverbindung](https://makecode.microbit.org/#tutorial:github:fave-smartfeld/pxt-smart-toilet-tutorial/docs/tutorials/smart-toilet-part2) erfolgreich beendet.
 
 Schwierigkeitsgrad: 🔥🔥⚪⚪
 
 ## 👁️ Voraussetzungen @showdialog
-* Schliesse den Cube so an, falls noch nicht gemacht:
+* Schliesse den Cube so an, falls du das noch nicht erledigt hast:
 ![Bild](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/iot-cube-anschliessen-klein.png)
 * Stelle die Schalter vorerst so ein:
     * Battery Switch: **off**
     * LoRa Module: **on**
 ![Bild](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/iot-cube-power-switches-klein.png)
-* Ein LoRa-Gateway🛜 muss in Reichweite sein, welches mit TTN (The Things Network) verbunden ist.
-Dies ist im Klassensatz einmal vorhanden und kann hunderte von IoT- Cubes bedienen.
+* Ein LoRa-Gateway🛜 muss in Reichweite und mit TTN (The Things Network) verbunden sein.
+  In jedem Klassensatz ist mindestens eines vorhanden, das Hunderte von IoT-Cubes bedienen kann.
 ![Bild](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/gateway-klein.png)
 
 ## Lernergebnis
 
-Aus den vorherigen Tutorials kennst du bereits, wie man den Status der Toilette 🚽 ("Besetzt" oder "Frei") per LoRa🛜 ins Internet sendet. Bisher hast du den Status durch Tastendruck ausgelöst. In einer echten Anwendung übernimmt das natürlich ein Sensor – und genau darum geht es in diesem Tutorial.
+Aus den vorherigen Tutorials kennst du bereits, wie man den Status der Toilette 🚽 ("Besetzt" oder "Frei") per LoRa🛜 ins Internet sendet. Bisher hast du den Status durch Tastendruck ausgelöst. In einer echten Anwendung übernimmt das ein Sensor – und genau darum geht es in diesem Tutorial.
 
-* Du baust dein kleines Toilettenhäuschen-Modell jetzt mit einem Taster (Magnetic Switch) aus.
+* Du baust dein Toilettenhäuschen-Modell jetzt mit einem Taster (Magnetic Switch) aus.
 
 Am Ende hast du ein Programm, das …
 
@@ -37,36 +37,36 @@ Am Ende hast du ein Programm, das …
 * den Status der Toilette 🚽 über den Taster erkennt
 * den Status 🚽 über LoRa🛜 ins Internet sendet
 
-Brauchbare Funktionen aus Teil 2 sind schon integriert, das Auswerten der Tasten A und B 
-wurden hingegen entfernt. 
+Brauchbare Funktionen aus Teil 2 sind schon integriert; das Auswerten der Tasten A und B
+wurde hingegen entfernt.
 
-Falls dir am bestehenden Code etwas unklar ist, lohnt es sich, 
-diesen Teil noch einmal durchzuarbeiten.
+Falls dir am bestehenden Code etwas unklar ist, lohnt es sich,
+diesen Teil noch einmal in Ruhe durchzugehen.
 
 ## Hardware vorbereiten
-* Du bekommst dieses WC- Häuschen- Modell: ![Bild](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/wc-haus.png)
-* Du brauchst zusätzlich dieses Kunststoffteil: [Taster- Aufnahme](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/3dModel/taster-halterung.html)
-* Falls du das Teil selbst 3D- Drucken möchtest, lade das STL- File hier herunter: [🌍STL-3D-Modell](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/3dModel/taster-halterung.stl)
+* Du bekommst dieses WC-Häuschen-Modell: ![Bild](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/wc-haus.png)
+* Du brauchst zusätzlich dieses Kunststoffteil: [Taster-Halterung](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/3dModel/taster-halterung.html)
+* Falls du das Teil selbst 3D-drucken möchtest, lade das STL-File hier herunter: [🌍 STL-3D-Modell](https://reifab.github.io/pxt-iot-tutorial/static/tutorials/3dModel/taster-halterung.stl)
 * Schliesse den Grove Magnetic Switch an **J3** an.
 
-## Magnet- Schalter🧲 auslesen
-Der Magnet-Schalter (Magnetic Switch) liefert ein digitales Signal, 
+## Magnet-Schalter🧲 auslesen
+Der Magnet-Schalter (Magnetic Switch) liefert ein digitales Signal,
 das wir einfach auswerten können:
 
 0 → kein Magnet in der Nähe → Tür offen
 
 1 → Magnet 🧲 in der Nähe → Tür geschlossen 
 
-Damit wir den Zustand der Tür laufend erkennen, lesen wir den Sensor in der 
-bestehenden ``||basic:dauerhaft||`` -Schleife regelmässig 
-aus und übersetzen das Signal in offen oder geschlossen.
+Damit wir den Zustand der Tür laufend erkennen, lesen wir den Sensor in der
+bestehenden ``||basic:dauerhaft||``-Schleife regelmässig
+aus und übersetzen das Signal in "offen" oder "geschlossen".
 
-*  ``||variables:Erstelle eine Variable...||`` und benenne sie **zustandTür**
-* Setze die Variable  **zustandTür** zuoberst in der 
-Dauerhaft- Schleife auf den Zustand, welcher am Pin P2 gemessen wird. Verwende
-dazu die Blöcke ``||variables:setze zustandTür auf 0||`` sowie 
-``||pins:digitale Werte von Pin P0||``, den du statt der 0 einfügst.
-* Ändere Pin P0 auf P2
+* ``||variables:Erstelle eine Variable...||`` und benenne sie **zustandTür**.
+* Setze die Variable **zustandTür** zuoberst in der
+``||basic:dauerhaft||``-Schleife auf den Zustand, der am Pin P2 gemessen wird. Verwende
+  dazu die Blöcke ``||variables:setze zustandTür auf 0||`` sowie
+  ``||pins:digitale Werte von Pin P0||`` und ersetze die 0 durch den Pins-Block.
+* Stelle im Pins-Block P0 auf P2 um.
 
 ```blocks
 //@hide
@@ -149,19 +149,18 @@ nehmen wir an, das WC sei **Frei**. Diese Zustände wollen wir einerseits
 anzeigen, andererseits über LoRa🛜 in die Claviscloud schicken, was 
 zum Glück beides schon vorbereitet ist.
 
-* Setze unter das Auslesen des Magnetic- Switches einen 
- ``||Logic:wenn wahr dann||``.  
-* Prüfe mit ``||logic:Vergleich 0 = 0||``, ob die ``||variables:zustandTür||`` 
-= 1  ist. (=Tür geschlossen).
-* Wenn dies der Fall ist, Rufe die Funktion ``||function:Aufruf macheBesetzt||`` auf,
-andernfalls ``||function:Aufruf macheFrei||``. (Die Funktionen sind im Bereich
-Fortgeschritten zu finden, allenfalls musst du diesen zuerst aufklappen)
-* Drücke 📥`|Download|`
-* Prüfe, ob in der Cloud Änderung des Zustandes (Frei oder Besetzt) angezeigt werden: 
-[iot.claviscloud.ch](https://iot.claviscloud.ch/dashboards/)
-* Behebe gegebenenfalls aufgetretene Fehler. Klicke auf das 💡- Symbol bei
-Schwierigkeiten.
-* Fällt Dir sonst noch etwas auf? Gibt es Dinge, die man optimieren könnte?
+* Setze unter das Auslesen des Magnetic Switch einen
+  ``||logic:wenn wahr dann||``-Block.
+* Prüfe mit ``||logic:Vergleich 0 = 0||``, ob ``||variables:zustandTür||``
+  den Wert 1 hat (Tür geschlossen).
+* Wenn dies der Fall ist, rufe die Funktion ``||function:Aufruf macheBesetzt||`` auf,
+  andernfalls ``||function:Aufruf macheFrei||``. (Die Funktionen findest du im Bereich
+  **Fortgeschritten** – klappe ihn bei Bedarf zuerst auf.)
+* Klicke auf 📥 `|Download|`.
+* Prüfe, ob in der Cloud die Änderung des Zustands (frei oder besetzt) angezeigt wird:
+  [iot.claviscloud.ch](https://iot.claviscloud.ch/dashboards/)
+* Behebe gegebenenfalls aufgetretene Fehler. Klicke auf das 💡-Symbol bei Schwierigkeiten.
+* Fällt dir sonst noch etwas auf? Gibt es Dinge, die du optimieren könntest?
 
 
 ```blocks
@@ -250,17 +249,17 @@ Das kostet unnötig Energie. Sinnvoller ist es, nur bei einer Änderung
 des Türzustands zu senden.
 
 * ``||variables:Erstelle eine Variable...||`` und benenne sie **zustandTürDavor**.
-* Setze ganz am Ende im Block ``beim Start`` die Variable 
-``||variables:zustandTürDavor||`` auf -1, damit sie sich beim ersten Durchlauf vom gemessenen Wert garantiert 
-unterscheidet: ``||variables:setze zustandTürDavor auf -1||``
-* Prüfe in der ``dauerhaft``- Schleife, ob sich die Variablen ``||variables:zustandTür||`` und ``||variables:zustandTürDavor||``
-unterscheiden (≠ Zeichen). Wenn ja, aktuallisiere **zustandTürDavor**
-und führe nur dann die bestehende Logik aus. Hier die Blöcke dafür:
-  * ``||logic:wenn wahr dann||`` sowie ``||logic:0 ≠ 0||`` und 
+* Setze ganz am Ende im Block ``beim Start`` die Variable
+  ``||variables:zustandTürDavor||`` auf -1, damit sie sich beim ersten Durchlauf garantiert
+  vom gemessenen Wert unterscheidet: ``||variables:setze zustandTürDavor auf -1||``
+* Prüfe in der ``||basic:dauerhaft||``-Schleife, ob sich die Variablen ``||variables:zustandTür||`` und ``||variables:zustandTürDavor||``
+  unterscheiden (≠-Vergleich). Wenn ja, aktualisiere **zustandTürDavor**
+  und führe nur dann die bestehende Logik aus. Verwende dafür diese Blöcke:
+  * ``||logic:wenn wahr dann||`` sowie ``||logic:0 ≠ 0||``
   * ``||variables:setze zustandTürDavor auf zustandTür||``
-  * Verschiebe nun deine bisherige Abfrage (Tür = 1) in diesen wenn-Block.
-  (Dadurch werden die Funktionen nur noch ausgeführt, wenn sich der Türzustand
-  ändert.)
+  * Verschiebe nun deine bisherige Abfrage (Tür = 1) in diesen Wenn-Block.
+    (Dadurch werden die Funktionen nur noch ausgeführt, wenn sich der Türzustand
+    ändert.)
 
 ```blocks
 //@hide
@@ -344,11 +343,11 @@ basic.forever(function () {
 })
 ```
 
-## Gratuliere 🏆 - du hast das Tutorial erfolgreich bearbeitet 🚀
+## Gratuliere 🏆 – du hast das Tutorial erfolgreich bearbeitet 🚀
 
-* Verbinde deine Smarte Toilette mit dem Toiletten Widget der [Claviscloud](https://iot.claviscloud.ch/)! 
-* Teste, ob die Daten korrekt angezeigt werden!
-* Falls irgendwas noch nicht richtig läuft, hier hast Du eine funktionierende Version zum Testen: [Lösung](https://makecode.microbit.org/#tutorial:github:reifab/pxt-smart-toilet-tutorial/docs/tutorials/smart-toilet-part3-solution)
+* Verbinde deine smarte Toilette mit dem Toiletten-Widget der [Claviscloud](https://iot.claviscloud.ch/).
+* Teste, ob die Daten korrekt angezeigt werden.
+* Falls etwas noch nicht richtig läuft, findest du hier eine funktionierende Version zum Testen: [Lösung](https://makecode.microbit.org/#tutorial:github:reifab/pxt-smart-toilet-tutorial/docs/tutorials/smart-toilet-part3-solution)
 
 ```template
 function macheFrei () {


### PR DESCRIPTION
## Summary
- fix spelling and hyphenation issues in the smart toilet part 3 tutorial
- clarify instructions for wiring, sensor logic, and cloud verification steps
- ensure the document closes code blocks correctly and ends with a newline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2a321ce808327a7cf631cbf306290